### PR TITLE
Changes for flox(pkgs) -> flox-lib renaming[CU-p7bj68]

### DIFF
--- a/channel/channel.nix
+++ b/channel/channel.nix
@@ -99,7 +99,7 @@ let
                 channels =
                   lib.mapAttrs (name: withWarningPrefix [ "channels" name ])
                   channelAttrs;
-                flox = withWarningPrefix [ "flox" ] channelAttrs.flox;
+                flox = withWarningPrefix [ "flox" ] channelAttrs.flox-lib;
                 floxPath = spec.path;
                 baseScope = baseScope';
                 superScope.${pname} = superPackage;

--- a/channel/own.nix
+++ b/channel/own.nix
@@ -14,10 +14,10 @@ let
 
     argDeps = firstArgs.dependencies or [ ];
 
-    # We need to be able to handle flox, nixpkgs and own channel entries here
-    # even if provided by another flox channel provider
+    # We need to be able to handle flox-lib, nixpkgs and own channel entries here
+    # even if provided by another flox-lib channel provider
     # Also we want nixpkgs to be in the list for determining the extends
-    allDeps = fileDeps ++ argDeps ++ [ "flox" "nixpkgs" channelName ];
+    allDeps = fileDeps ++ argDeps ++ [ "flox-lib" "nixpkgs" channelName ];
 
   in lib.genAttrs allDeps (x: null);
 

--- a/channel/resolve.nix
+++ b/channel/resolve.nix
@@ -4,9 +4,9 @@
 let
 
   options = channels // {
-    nixpkgs = if channels ? nixpkgs.valid && channels ? flox.valid then {
+    nixpkgs = if channels ? nixpkgs.valid && channels ? flox-lib.valid then {
       invalid = "nixpkgs can't be selected for packages also provided by "
-        + "the flox channel, since it provides a standard and "
+        + "the flox-lib channel, since it provides a standard and "
         + "essential superset of nixpkgs functionality";
     } else
       channels.nixpkgs;

--- a/channel/root.nix
+++ b/channel/root.nix
@@ -90,7 +90,7 @@ let
     sanitizeResult = name: result:
       result // {
         dependencies =
-          removeAttrs (result.dependencies // { flox = null; }) [ name ];
+          removeAttrs (result.dependencies // { flox-lib = null; }) [ name ];
       };
 
     root = {

--- a/channel/tests/accessing-flox/channels/test/default.nix
+++ b/channel/tests/accessing-flox/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/accessing-flox/config.nix
+++ b/channel/tests/accessing-flox/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/callPackage/channels/test/default.nix
+++ b/channel/tests/callPackage/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/callPackage/config.nix
+++ b/channel/tests/callPackage/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/channel-dep-case-insensitive/channels/Other/default.nix
+++ b/channel/tests/channel-dep-case-insensitive/channels/Other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep-case-insensitive/channels/test/default.nix
+++ b/channel/tests/channel-dep-case-insensitive/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep-case-insensitive/config.nix
+++ b/channel/tests/channel-dep-case-insensitive/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/channel-dep-fail/channels/other/default.nix
+++ b/channel/tests/channel-dep-fail/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep-fail/channels/test/default.nix
+++ b/channel/tests/channel-dep-fail/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep-fail/config.nix
+++ b/channel/tests/channel-dep-fail/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/channel-dep-not-found/channels/other/default.nix
+++ b/channel/tests/channel-dep-not-found/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep-not-found/channels/test/default.nix
+++ b/channel/tests/channel-dep-not-found/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep-not-found/config.nix
+++ b/channel/tests/channel-dep-not-found/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/channel-dep/channels/other/default.nix
+++ b/channel/tests/channel-dep/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep/channels/test/default.nix
+++ b/channel/tests/channel-dep/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/channel-dep/config.nix
+++ b/channel/tests/channel-dep/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-channel-override-order/channels/other/default.nix
+++ b/channel/tests/deep-channel-override-order/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-channel-override-order/channels/test/default.nix
+++ b/channel/tests/deep-channel-override-order/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-channel-override-order/config.nix
+++ b/channel/tests/deep-channel-override-order/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-channel-override/channels/other/default.nix
+++ b/channel/tests/deep-channel-override/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-channel-override/channels/test/default.nix
+++ b/channel/tests/deep-channel-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-channel-override/config.nix
+++ b/channel/tests/deep-channel-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-erlang-override/channels/test/default.nix
+++ b/channel/tests/deep-erlang-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-erlang-override/config.nix
+++ b/channel/tests/deep-erlang-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-haskell-override/channels/test/default.nix
+++ b/channel/tests/deep-haskell-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-haskell-override/config.nix
+++ b/channel/tests/deep-haskell-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-override-nonexistent/channels/test/default.nix
+++ b/channel/tests/deep-override-nonexistent/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-override-nonexistent/config.nix
+++ b/channel/tests/deep-override-nonexistent/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-override-output/channels/test/default.nix
+++ b/channel/tests/deep-override-output/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-override-output/config.nix
+++ b/channel/tests/deep-override-output/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-override/channels/test/default.nix
+++ b/channel/tests/deep-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-override/config.nix
+++ b/channel/tests/deep-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-perl-override/channels/test/default.nix
+++ b/channel/tests/deep-perl-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-perl-override/config.nix
+++ b/channel/tests/deep-perl-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/deep-python-override/channels/test/default.nix
+++ b/channel/tests/deep-python-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/deep-python-override/config.nix
+++ b/channel/tests/deep-python-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/dep-override/channels/test/default.nix
+++ b/channel/tests/dep-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/dep-override/config.nix
+++ b/channel/tests/dep-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/flox-getBuilderSource/channels/other/default.nix
+++ b/channel/tests/flox-getBuilderSource/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getBuilderSource/channels/test/default.nix
+++ b/channel/tests/flox-getBuilderSource/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getBuilderSource/config.nix
+++ b/channel/tests/flox-getBuilderSource/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/flox-getSource-override-branch/channels/test/default.nix
+++ b/channel/tests/flox-getSource-override-branch/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getSource-override-branch/config.nix
+++ b/channel/tests/flox-getSource-override-branch/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/flox-getSource-override-rev/channels/test/default.nix
+++ b/channel/tests/flox-getSource-override-rev/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getSource-override-rev/config.nix
+++ b/channel/tests/flox-getSource-override-rev/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/flox-getSource-override-src/channels/test/default.nix
+++ b/channel/tests/flox-getSource-override-src/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getSource-override-src/config.nix
+++ b/channel/tests/flox-getSource-override-src/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/flox-getSource-sourceOverride/channels/test/default.nix
+++ b/channel/tests/flox-getSource-sourceOverride/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getSource-sourceOverride/config.nix
+++ b/channel/tests/flox-getSource-sourceOverride/config.nix
@@ -15,7 +15,7 @@ in {
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/flox-getSource-sourceOverrides-multiple/channels/other/default.nix
+++ b/channel/tests/flox-getSource-sourceOverrides-multiple/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getSource-sourceOverrides-multiple/channels/test/default.nix
+++ b/channel/tests/flox-getSource-sourceOverrides-multiple/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getSource-sourceOverrides-multiple/config.nix
+++ b/channel/tests/flox-getSource-sourceOverrides-multiple/config.nix
@@ -21,7 +21,7 @@ in {
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/flox-getSource/channels/test/default.nix
+++ b/channel/tests/flox-getSource/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/flox-getSource/config.nix
+++ b/channel/tests/flox-getSource/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/floxPath/channels/test/default.nix
+++ b/channel/tests/floxPath/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/floxPath/config.nix
+++ b/channel/tests/floxPath/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/hydra-recurse/channels/test/default.nix
+++ b/channel/tests/hydra-recurse/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/hydra-recurse/config.nix
+++ b/channel/tests/hydra-recurse/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/importNix/channels/root/default.nix
+++ b/channel/tests/importNix/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/importNix/config.nix
+++ b/channel/tests/importNix/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/importNix_floxPath/channels/root/default.nix
+++ b/channel/tests/importNix_floxPath/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/importNix_floxPath/config.nix
+++ b/channel/tests/importNix_floxPath/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/importingChannel/channels/root/default.nix
+++ b/channel/tests/importingChannel/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/importingChannel/channels/test/default.nix
+++ b/channel/tests/importingChannel/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/importingChannel/config.nix
+++ b/channel/tests/importingChannel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/lazy-conflicts/channels/bar/default.nix
+++ b/channel/tests/lazy-conflicts/channels/bar/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/lazy-conflicts/channels/foo/default.nix
+++ b/channel/tests/lazy-conflicts/channels/foo/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/lazy-conflicts/channels/test/default.nix
+++ b/channel/tests/lazy-conflicts/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/lazy-conflicts/config.nix
+++ b/channel/tests/lazy-conflicts/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/mapDirectory/channels/test/default.nix
+++ b/channel/tests/mapDirectory/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/mapDirectory/config.nix
+++ b/channel/tests/mapDirectory/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/name-baseName/channels/test/default.nix
+++ b/channel/tests/name-baseName/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/name-baseName/config.nix
+++ b/channel/tests/name-baseName/config.nix
@@ -8,7 +8,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/name-chanArg/channels/test/default.nix
+++ b/channel/tests/name-chanArg/channels/test/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   name = "test";
 }

--- a/channel/tests/name-chanArg/config.nix
+++ b/channel/tests/name-chanArg/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/name-cmdArg/channels/test/default.nix
+++ b/channel/tests/name-cmdArg/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/name-cmdArg/config.nix
+++ b/channel/tests/name-cmdArg/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/name-gitConfig/channels/test/default.nix
+++ b/channel/tests/name-gitConfig/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/name-gitConfig/config.nix
+++ b/channel/tests/name-gitConfig/config.nix
@@ -22,7 +22,7 @@ in {
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/name-unknown-src/channels/test/default.nix
+++ b/channel/tests/name-unknown-src/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/name-unknown-src/config.nix
+++ b/channel/tests/name-unknown-src/config.nix
@@ -8,7 +8,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/name-unknown/channels/test/default.nix
+++ b/channel/tests/name-unknown/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/name-unknown/config.nix
+++ b/channel/tests/name-unknown/config.nix
@@ -8,7 +8,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/one-package-file/channels/test/default.nix
+++ b/channel/tests/one-package-file/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/one-package-file/config.nix
+++ b/channel/tests/one-package-file/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/one-package/channels/test/default.nix
+++ b/channel/tests/one-package/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/one-package/config.nix
+++ b/channel/tests/one-package/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/override-nixpkgs-throw/channels/other/default.nix
+++ b/channel/tests/override-nixpkgs-throw/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/override-nixpkgs-throw/channels/test/default.nix
+++ b/channel/tests/override-nixpkgs-throw/channels/test/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.gnupg20 = "other";
 }

--- a/channel/tests/override-nixpkgs-throw/config.nix
+++ b/channel/tests/override-nixpkgs-throw/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/package-python-channel-dep/channels/other/default.nix
+++ b/channel/tests/package-python-channel-dep/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/package-python-channel-dep/channels/test/default.nix
+++ b/channel/tests/package-python-channel-dep/channels/test/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pythonPackages.toml = "other";
 }

--- a/channel/tests/package-python-channel-dep/config.nix
+++ b/channel/tests/package-python-channel-dep/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/package-python-dep-override/channels/test/default.nix
+++ b/channel/tests/package-python-dep-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/package-python-dep-override/config.nix
+++ b/channel/tests/package-python-dep-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/package-python-override/channels/test/default.nix
+++ b/channel/tests/package-python-override/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/package-python-override/config.nix
+++ b/channel/tests/package-python-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/package-python/channels/test/default.nix
+++ b/channel/tests/package-python/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/package-python/config.nix
+++ b/channel/tests/package-python/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/package-set-pregen-fail/channels/test/default.nix
+++ b/channel/tests/package-set-pregen-fail/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/package-set-pregen-fail/config.nix
+++ b/channel/tests/package-set-pregen-fail/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/package-set-pregen-success/channels/test/default.nix
+++ b/channel/tests/package-set-pregen-success/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/package-set-pregen-success/config.nix
+++ b/channel/tests/package-set-pregen-success/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/recursive-channel-deps/channels/a/default.nix
+++ b/channel/tests/recursive-channel-deps/channels/a/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/recursive-channel-deps/channels/b/default.nix
+++ b/channel/tests/recursive-channel-deps/channels/b/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/recursive-channel-deps/config.nix
+++ b/channel/tests/recursive-channel-deps/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/returnFloxPath/channels/test/default.nix
+++ b/channel/tests/returnFloxPath/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/returnFloxPath/config.nix
+++ b/channel/tests/returnFloxPath/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/returnFloxPathDeep/channels/root/default.nix
+++ b/channel/tests/returnFloxPathDeep/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/returnFloxPathDeep/config.nix
+++ b/channel/tests/returnFloxPathDeep/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-channel-channel/channels/bar/default.nix
+++ b/channel/tests/root-conflict-channel-channel/channels/bar/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-channel-channel/channels/foo/default.nix
+++ b/channel/tests/root-conflict-channel-channel/channels/foo/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-channel-channel/channels/test/default.nix
+++ b/channel/tests/root-conflict-channel-channel/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-channel-channel/config.nix
+++ b/channel/tests/root-conflict-channel-channel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-flox-override-fail/channels/other/default.nix
+++ b/channel/tests/root-conflict-flox-override-fail/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-flox-override-fail/channels/test/default.nix
+++ b/channel/tests/root-conflict-flox-override-fail/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-flox-override-fail/config.nix
+++ b/channel/tests/root-conflict-flox-override-fail/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-flox-override-fail/stderr
+++ b/channel/tests/root-conflict-flox-override-fail/stderr
@@ -1,3 +1,3 @@
-error: The package pkgs.buildGoModule is being used. However there are multiple channels which provide that package. No conflict resolution is currently provided. Valid options are \[ "flox", "other" \]. Set the conflict resolution for this package in .*/test/default.nix by copying one of the following lines to it:
-conflictResolution.pkgs.buildGoModule = "flox";
+error: The package pkgs.buildGoModule is being used. However there are multiple channels which provide that package. No conflict resolution is currently provided. Valid options are \[ "flox-lib", "other" \]. Set the conflict resolution for this package in .*/test/default.nix by copying one of the following lines to it:
+conflictResolution.pkgs.buildGoModule = "flox-lib";
 conflictResolution.pkgs.buildGoModule = "other";

--- a/channel/tests/root-conflict-flox-override/channels/other/default.nix
+++ b/channel/tests/root-conflict-flox-override/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-flox-override/channels/test/default.nix
+++ b/channel/tests/root-conflict-flox-override/channels/test/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.buildGoModule = "other";
 }

--- a/channel/tests/root-conflict-flox-override/config.nix
+++ b/channel/tests/root-conflict-flox-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-flox-specialcase/channels/test/default.nix
+++ b/channel/tests/root-conflict-flox-specialcase/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-flox-specialcase/config.nix
+++ b/channel/tests/root-conflict-flox-specialcase/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-flox-specialcase/stdout
+++ b/channel/tests/root-conflict-flox-specialcase/stdout
@@ -1,1 +1,1 @@
-".*-flox/pkgs/buildGoModule.nix"
+".*-flox-lib/pkgs/buildGoModule.nix"

--- a/channel/tests/root-conflict-nixpkgs-channel/channels/foo/default.nix
+++ b/channel/tests/root-conflict-nixpkgs-channel/channels/foo/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-nixpkgs-channel/channels/test/default.nix
+++ b/channel/tests/root-conflict-nixpkgs-channel/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-nixpkgs-channel/config.nix
+++ b/channel/tests/root-conflict-nixpkgs-channel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-root-package-channel/channels/other/default.nix
+++ b/channel/tests/root-conflict-root-package-channel/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-root-package-channel/channels/test/default.nix
+++ b/channel/tests/root-conflict-root-package-channel/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-root-package-channel/config.nix
+++ b/channel/tests/root-conflict-root-package-channel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-root-package-nixpkgs/channels/test/default.nix
+++ b/channel/tests/root-conflict-root-package-nixpkgs/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-root-package-nixpkgs/config.nix
+++ b/channel/tests/root-conflict-root-package-nixpkgs/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/root-conflict-single-channel/channels/other/default.nix
+++ b/channel/tests/root-conflict-single-channel/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-single-channel/channels/test/default.nix
+++ b/channel/tests/root-conflict-single-channel/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/root-conflict-single-channel/config.nix
+++ b/channel/tests/root-conflict-single-channel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/subdir/channels/test/default.nix
+++ b/channel/tests/subdir/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/subdir/config.nix
+++ b/channel/tests/subdir/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-chain-cycle-fail/channels/bar/default.nix
+++ b/channel/tests/super-conflict-chain-cycle-fail/channels/bar/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain-cycle-fail/channels/foo/default.nix
+++ b/channel/tests/super-conflict-chain-cycle-fail/channels/foo/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain-cycle-fail/channels/test/default.nix
+++ b/channel/tests/super-conflict-chain-cycle-fail/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain-cycle-fail/config.nix
+++ b/channel/tests/super-conflict-chain-cycle-fail/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-chain-cycle/channels/bar/default.nix
+++ b/channel/tests/super-conflict-chain-cycle/channels/bar/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain-cycle/channels/foo/default.nix
+++ b/channel/tests/super-conflict-chain-cycle/channels/foo/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain-cycle/channels/test/default.nix
+++ b/channel/tests/super-conflict-chain-cycle/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain-cycle/config.nix
+++ b/channel/tests/super-conflict-chain-cycle/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-chain-resolving/channels/bar/default.nix
+++ b/channel/tests/super-conflict-chain-resolving/channels/bar/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain-resolving/channels/foo/default.nix
+++ b/channel/tests/super-conflict-chain-resolving/channels/foo/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.testPackage = "bar";
 }

--- a/channel/tests/super-conflict-chain-resolving/channels/test/default.nix
+++ b/channel/tests/super-conflict-chain-resolving/channels/test/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.testPackage = "foo";
 }

--- a/channel/tests/super-conflict-chain-resolving/config.nix
+++ b/channel/tests/super-conflict-chain-resolving/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-chain/channels/bar/default.nix
+++ b/channel/tests/super-conflict-chain/channels/bar/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain/channels/foo/default.nix
+++ b/channel/tests/super-conflict-chain/channels/foo/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain/channels/test/default.nix
+++ b/channel/tests/super-conflict-chain/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-chain/config.nix
+++ b/channel/tests/super-conflict-chain/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-channel-channel/channels/bar/default.nix
+++ b/channel/tests/super-conflict-channel-channel/channels/bar/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-channel-channel/channels/foo/default.nix
+++ b/channel/tests/super-conflict-channel-channel/channels/foo/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-channel-channel/channels/test/default.nix
+++ b/channel/tests/super-conflict-channel-channel/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-channel-channel/config.nix
+++ b/channel/tests/super-conflict-channel-channel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-nixpkgs-channel/channels/florp/default.nix
+++ b/channel/tests/super-conflict-nixpkgs-channel/channels/florp/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-nixpkgs-channel/channels/test/default.nix
+++ b/channel/tests/super-conflict-nixpkgs-channel/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-nixpkgs-channel/config.nix
+++ b/channel/tests/super-conflict-nixpkgs-channel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-nixpkgs/channels/test/default.nix
+++ b/channel/tests/super-conflict-nixpkgs/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-nixpkgs/config.nix
+++ b/channel/tests/super-conflict-nixpkgs/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-none/channels/test/default.nix
+++ b/channel/tests/super-conflict-none/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-none/config.nix
+++ b/channel/tests/super-conflict-none/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-none/stderr
+++ b/channel/tests/super-conflict-none/stderr
@@ -1,4 +1,4 @@
 error: In the definition of the pkgs.testPackage package in .*/test/pkgs/testPackage.nix, the argument testPackage itself is being used, which points to the unoverridden version of the same package. However, none of the channels are a valid option:
-- flox: the package doesn't exist in this channel
+- flox-lib: the package doesn't exist in this channel
 - nixpkgs: this package doesn't exist in nixpkgs
 - test: The super version can't come from its own channel

--- a/channel/tests/super-conflict-nonexistent-channel/channels/other/default.nix
+++ b/channel/tests/super-conflict-nonexistent-channel/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-nonexistent-channel/channels/test/default.nix
+++ b/channel/tests/super-conflict-nonexistent-channel/channels/test/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.testPackage = "florp";
 }

--- a/channel/tests/super-conflict-nonexistent-channel/config.nix
+++ b/channel/tests/super-conflict-nonexistent-channel/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-nonexistent-package/channels/florp/default.nix
+++ b/channel/tests/super-conflict-nonexistent-package/channels/florp/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.testPackage = "florp";
 }

--- a/channel/tests/super-conflict-nonexistent-package/channels/test/default.nix
+++ b/channel/tests/super-conflict-nonexistent-package/channels/test/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.testPackage = "florp";
 }

--- a/channel/tests/super-conflict-nonexistent-package/config.nix
+++ b/channel/tests/super-conflict-nonexistent-package/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-nonexistent-package/stderr
+++ b/channel/tests/super-conflict-nonexistent-package/stderr
@@ -1,5 +1,5 @@
 error: In the definition of the pkgs.testPackage package in .*/test/pkgs/testPackage.nix, the argument testPackage itself is being used, which points to the unoverridden version of the same package. However, none of the channels are a valid option:
 - florp: the package doesn't exist in this channel
-- flox: the package doesn't exist in this channel
+- flox-lib: the package doesn't exist in this channel
 - nixpkgs: this package doesn't exist in nixpkgs
 - test: The super version can't come from its own channel

--- a/channel/tests/super-conflict-transitive/channels/other/default.nix
+++ b/channel/tests/super-conflict-transitive/channels/other/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-transitive/channels/other2/default.nix
+++ b/channel/tests/super-conflict-transitive/channels/other2/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-transitive/channels/test/default.nix
+++ b/channel/tests/super-conflict-transitive/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/super-conflict-transitive/config.nix
+++ b/channel/tests/super-conflict-transitive/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/super-conflict-transitive/stderr
+++ b/channel/tests/super-conflict-transitive/stderr
@@ -1,5 +1,5 @@
 error: In the definition of the pkgs.foo package in .*/test/pkgs/foo.nix, the argument foo itself is being used, which points to the unoverridden version of the same package. However, none of the channels are a valid option:
-- flox: the package doesn't exist in this channel
+- flox-lib: the package doesn't exist in this channel
 - nixpkgs: this package doesn't exist in nixpkgs
 - other: the package doesn't exist in this channel
 - other2: the package exists in this channel, but it is not defined as a direct dependency

--- a/channel/tests/trivial/channels/test/default.nix
+++ b/channel/tests/trivial/channels/test/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/channel/tests/trivial/config.nix
+++ b/channel/tests/trivial/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/utils-callPackageWith/config.nix
+++ b/channel/tests/utils-callPackageWith/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/utils-callPackageWith/expression.nix
+++ b/channel/tests/utils-callPackageWith/expression.nix
@@ -1,6 +1,6 @@
 let
   lib = import <nixpkgs/lib>;
-  utils = import <flox/channel/utils> { inherit lib; };
+  utils = import <flox-lib/channel/utils> { inherit lib; };
 
   result = utils.callPackageWith (utils.traceWith { }) { foo = 10; } <file>;
 

--- a/channel/tests/utils-modifyPaths/config.nix
+++ b/channel/tests/utils-modifyPaths/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/utils-modifyPaths/expression.nix
+++ b/channel/tests/utils-modifyPaths/expression.nix
@@ -1,6 +1,6 @@
 let
   lib = import <nixpkgs/lib>;
-  utils = import <flox/channel/utils> { inherit lib; };
+  utils = import <flox-lib/channel/utils> { inherit lib; };
 
   result = utils.modifyPaths [
     # Override with a throw

--- a/channel/tests/utils-nestedListToAttrs-fail/config.nix
+++ b/channel/tests/utils-nestedListToAttrs-fail/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/utils-nestedListToAttrs-fail/expression.nix
+++ b/channel/tests/utils-nestedListToAttrs-fail/expression.nix
@@ -1,6 +1,6 @@
 let
   lib = import <nixpkgs/lib>;
-  utils = import <flox/channel/utils> { inherit lib; };
+  utils = import <flox-lib/channel/utils> { inherit lib; };
 
   result = utils.nestedListToAttrs (utils.traceWith { }) [
     {

--- a/channel/tests/utils-nestedListToAttrs-lazy/config.nix
+++ b/channel/tests/utils-nestedListToAttrs-lazy/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/utils-nestedListToAttrs-lazy/expression.nix
+++ b/channel/tests/utils-nestedListToAttrs-lazy/expression.nix
@@ -1,6 +1,6 @@
 let
   lib = import <nixpkgs/lib>;
-  utils = import <flox/channel/utils> { inherit lib; };
+  utils = import <flox-lib/channel/utils> { inherit lib; };
 
   result = utils.nestedListToAttrs (utils.traceWith { }) [
     {

--- a/channel/tests/utils-nestedListToAttrs/config.nix
+++ b/channel/tests/utils-nestedListToAttrs/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/utils-nestedListToAttrs/expression.nix
+++ b/channel/tests/utils-nestedListToAttrs/expression.nix
@@ -1,6 +1,6 @@
 let
   lib = import <nixpkgs/lib>;
-  utils = import <flox/channel/utils> { inherit lib; };
+  utils = import <flox-lib/channel/utils> { inherit lib; };
 
   result = utils.nestedListToAttrs (utils.traceWith { }) [
     {

--- a/channel/tests/utils-tracing/config.nix
+++ b/channel/tests/utils-tracing/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/channel/tests/utils-tracing/expression.nix
+++ b/channel/tests/utils-tracing/expression.nix
@@ -1,6 +1,6 @@
 let
   lib = import <nixpkgs/lib>;
-  utils = import <flox/channel/utils> { inherit lib; };
+  utils = import <flox-lib/channel/utils> { inherit lib; };
   trace = utils.traceWith {
     defaultVerbosity = 0;
     subsystemVerbosities.baz = 1;

--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/docs/channel-construction.md
+++ b/docs/channel-construction.md
@@ -1,12 +1,12 @@
 # Channel construction
 
-Each channel needs to have a `default.nix` in its root that calls the `<flox/channel>` function to construct a channel, which allows the user to run `nix-build` to build outputs, Hydra to find all outputs, and other channels to use this channel as a dependency. The entrypoint of this function is in [`flox/channel/default.nix`](../channel/default.nix).
+Each channel needs to have a `default.nix` in its root that calls the `<flox-lib/channel>` function to construct a channel, which allows the user to run `nix-build` to build outputs, Hydra to find all outputs, and other channels to use this channel as a dependency. The entrypoint of this function is in [`flox-lib/channel/default.nix`](../channel/default.nix).
 
 ## Channel file arguments
 
-A call to `<flox/channel>` in a channels root `default.nix` file usually looks like
+A call to `<flox-lib/channel>` in a channels root `default.nix` file usually looks like
 ```nix
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
 }
 ```

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -67,15 +67,15 @@ Tracing can be configured by setting a default minimum verbosity with the `--arg
 $ nix-build -A testPackage --arg debugVerbosity 9
 trace: <closure:1> Determining channel closure
 trace: <name:2> Determined root channel name to be root with heuristic baseName
-trace: <closure:2> Channel root depends on flox
-trace: <pregen:1> Reusing pregenerated /home/infinisil/j/tweag/clients/deshaw/flox/channels/nixpkgs-pregen/package-sets.json
+trace: <closure:2> Channel root depends on flox-lib
+trace: <pregen:1> Reusing pregenerated /home/infinisil/nixpkgs-pregen/package-sets.json
 trace: <dirToAttrs:5> [dir=root/beamPackages] Not importing any attributes because the directory doesn't exist
 trace: <dirToAttrs:5> [dir=root/haskellPackages] Not importing any attributes because the directory doesn't exist
 trace: <dirToAttrs:5> [dir=root/perlPackages] Not importing any attributes because the directory doesn't exist
 trace: <dirToAttrs:4> [dir=root/pkgs] Importing these attributes from directory: other, testPackage
 trace: <dirToAttrs:5> [dir=root/pythonPackages] Not importing any attributes because the directory doesn't exist
 trace: <nestedListToAttrs:9> [importingChannel=root] [channel=root] Called with index 0 and list paths [ [ ] ]
-trace: <callPackageWith:6> [importingChannel=root] [channel=root] [packageSet=pkgs] [version=none] [package=testPackage] Calling file /home/infinisil/j/tweag/clients/deshaw/flox/channels/root/pkgs/testPackage.nix
+trace: <callPackageWith:6> [importingChannel=root] [channel=root] [packageSet=pkgs] [version=none] [package=testPackage] Calling file /home/infinisil/.cache/floxpkgs/root/pkgs/testPackage.nix
 trace: <dirToAttrs:4> [dir=flox/pkgs] Importing these attributes from directory: buildGoModule, buildGoPackage, buildRustPackage, linkDotfiles, mkDerivation, naersk, removePathDups
 trace: <pathsToModify:2> [importingChannel=root] [pathsToModifyType=shallow] [packageSet=pkgs] [version=none] Injecting attributes into path [ ]: [ "buildGoModule" "buildGoPackage" "buildRustPackage" "linkDotfiles" "mkDerivation" "naersk" "other" "removePathDups" "testPackage" ]
 /nix/store/apbhxds141wrib2yg53zg1njkryhfk0b-test
@@ -89,10 +89,10 @@ In addition to setting a default verbosity, it's possible to override the verbos
 $ nix-build -A testPackage --arg debugVerbosity 9 --arg subsystemVerbosities '{ dirToAttrs = 0; }'
 trace: <closure:1> Determining channel closure
 trace: <name:2> Determined root channel name to be root with heuristic baseName
-trace: <closure:2> Channel root depends on flox
-trace: <pregen:1> Reusing pregenerated /home/infinisil/j/tweag/clients/deshaw/flox/channels/nixpkgs-pregen/package-sets.json
+trace: <closure:2> Channel root depends on flox-lib
+trace: <pregen:1> Reusing pregenerated /home/infinisil/nixpkgs-pregen/package-sets.json
 trace: <nestedListToAttrs:9> [importingChannel=root] [channel=root] Called with index 0 and list paths [ [ ] ]
-trace: <callPackageWith:6> [importingChannel=root] [channel=root] [packageSet=pkgs] [version=none] [package=testPackage] Calling file /home/infinisil/j/tweag/clients/deshaw/flox/channels/root/pkgs/testPackage.nix
+trace: <callPackageWith:6> [importingChannel=root] [channel=root] [packageSet=pkgs] [version=none] [package=testPackage] Calling file /home/infinisil/.cache/floxpkgs/root/pkgs/testPackage.nix
 trace: <pathsToModify:2> [importingChannel=root] [pathsToModifyType=shallow] [packageSet=pkgs] [version=none] Injecting attributes into path [ ]: [ "buildGoModule" "buildGoPackage" "buildRustPackage" "linkDotfiles" "mkDerivation" "naersk" "other" "removePathDups" "testPackage" ]
 /nix/store/apbhxds141wrib2yg53zg1njkryhfk0b-test
 ```

--- a/docs/expl/name-inference.md
+++ b/docs/expl/name-inference.md
@@ -1,15 +1,15 @@
 # Channel Name Inference Motivation and Complexities
 
-An evaluation of `<flox/channel>` for [constructing a flox channel](../channel-construction.md) makes a big effort to infer the channel name that's being evaluated. A channel might be evaluated with `nix-build '<myChan>' -A foo`, where `<myChan/default.nix>` contains the expression
+An evaluation of `<flox-lib/channel>` for [constructing a flox channel](../channel-construction.md) makes a big effort to infer the channel name that's being evaluated. A channel might be evaluated with `nix-build '<myChan>' -A foo`, where `<myChan/default.nix>` contains the expression
 ```nix
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
 }
 ```
 
 It is possible to specify the name explicitly with
 ```nix
-import <flox/channel> {
+import <flox-lib/channel> {
   name = "myChan";
   topdir = ./.;
 }
@@ -41,7 +41,7 @@ By knowing that the channel we're evaluating is `A`, we can override the path fo
 
 ## Why it's so complicated
 
-Channel name inference is not trivial however: The only information that the `<flox/channel>` function gets is the `topdir` value. Since there's a variety of ways in which the channel can be evaluated, a number of heuristics are used to try to infer the name:
+Channel name inference is not trivial however: The only information that the `<flox-lib/channel>` function gets is the `topdir` value. Since there's a variety of ways in which the channel can be evaluated, a number of heuristics are used to try to infer the name:
 - By looking at the base name of the topdir: This is the easiest way to infer the name in cases where the directory name is the same as the channel. This won't trigger when the base name is just "floxpkgs" however, which is the standard name git would name it when cloning.
 - By looking at the git remotes in the git config: In case the floxpkgs repository is a git checkout, this is very reliable
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,7 +1,7 @@
 # Flox channel docs
 
 The following pages exist:
-- [Channel construction](./channel-construction.md): Reference for the `<flox/channel>` entrypoint used to declare flox channels
+- [Channel construction](./channel-construction.md): Reference for the `<flox-lib/channel>` entrypoint used to declare flox channels
 - [Flox builders](./builders.md): Reference to the flox builders, supporting the `project` argument for automatic source updates
 - [Flox channel outputs](./flox-channel.md): Reference to non-builder attributes that the flox channel provides
 - [Package conflicts](./conflicts.md): Tutorial of how package conflicts can be resolved and why they occur

--- a/tests/cases/buildGoModule/channels/root/default.nix
+++ b/tests/cases/buildGoModule/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/buildGoModule/config.nix
+++ b/tests/cases/buildGoModule/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/buildGoPackage/channels/root/default.nix
+++ b/tests/cases/buildGoPackage/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/buildGoPackage/config.nix
+++ b/tests/cases/buildGoPackage/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/buildPerlPackage/channels/root/default.nix
+++ b/tests/cases/buildPerlPackage/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/buildPerlPackage/config.nix
+++ b/tests/cases/buildPerlPackage/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/buildPythonApplication/channels/root/default.nix
+++ b/tests/cases/buildPythonApplication/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/buildPythonApplication/config.nix
+++ b/tests/cases/buildPythonApplication/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/buildPythonPackage-unoverridable/channels/root/default.nix
+++ b/tests/cases/buildPythonPackage-unoverridable/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/buildPythonPackage-unoverridable/config.nix
+++ b/tests/cases/buildPythonPackage-unoverridable/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/buildPythonPackage/channels/root/default.nix
+++ b/tests/cases/buildPythonPackage/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/buildPythonPackage/config.nix
+++ b/tests/cases/buildPythonPackage/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/buildRustPackage/channels/root/default.nix
+++ b/tests/cases/buildRustPackage/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/buildRustPackage/config.nix
+++ b/tests/cases/buildRustPackage/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/builder-override/channels/builder/default.nix
+++ b/tests/cases/builder-override/channels/builder/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/builder-override/channels/root/default.nix
+++ b/tests/cases/builder-override/channels/root/default.nix
@@ -1,4 +1,4 @@
-import <flox/channel> {
+import <flox-lib/channel> {
   topdir = ./.;
   conflictResolution.pkgs.mkDerivation = "builder";
 }

--- a/tests/cases/builder-override/config.nix
+++ b/tests/cases/builder-override/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/haskellMkDerivation/channels/root/default.nix
+++ b/tests/cases/haskellMkDerivation/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/haskellMkDerivation/config.nix
+++ b/tests/cases/haskellMkDerivation/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/mkDerivation-unoverridable/channels/root/default.nix
+++ b/tests/cases/mkDerivation-unoverridable/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/mkDerivation-unoverridable/config.nix
+++ b/tests/cases/mkDerivation-unoverridable/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/mkDerivation/channels/root/default.nix
+++ b/tests/cases/mkDerivation/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/mkDerivation/config.nix
+++ b/tests/cases/mkDerivation/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/cases/naerskBuildRustPackage/channels/root/default.nix
+++ b/tests/cases/naerskBuildRustPackage/channels/root/default.nix
@@ -1,1 +1,1 @@
-import <flox/channel> { topdir = ./.; }
+import <flox-lib/channel> { topdir = ./.; }

--- a/tests/cases/naerskBuildRustPackage/config.nix
+++ b/tests/cases/naerskBuildRustPackage/config.nix
@@ -7,7 +7,7 @@
       path = nixpkgs;
     }
     {
-      prefix = "flox";
+      prefix = "flox-lib";
       path = repo;
     }
     {

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -2,7 +2,7 @@ dir:
 let
 
   repo = builtins.path {
-    name = "flox";
+    name = "flox-lib";
     path = ../.;
   };
 


### PR DESCRIPTION
From now on, the flox channel is now the flox-lib channel. It contains
all the Nix code to make channels work together, and all the standard
builders. It will newly be added as a special entry to NIX_PATH.

This allows using the `flox` channel namespace for actual flox packages.

<!--

Thank you for your contribution!

To keep this project of high quality, please make sure to tick all the
following boxes before sending your pull request.

Your pull request will automatically have its tests run and spelling checked,
but if you would like to run these checks locally, you can do so:

Run your tests locally with:

    nix-build channel/tests && ./result
    nix-build tests && ./result

Check the spelling of your documentation with codespell:

    git ls-files | nix-shell -p findutils codespell --run "xargs codespell -q 2"

Reformat your changes with nixfmt:

    git ls-files | grep '.nix$' | nix-shell -p findutils nixfmt --run "xargs nixfmt"

-->

- [ ] I have created a test to cover the new behavior.
- [ ] I have written and updated relevant documentation, including updating this
      pull request template if necessary. Note that we try to follow the
      [Divio documentation](https://documentation.divio.com/) of documentation.

